### PR TITLE
Add visualization script for X0 graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # Final
+
 final formula
+
+## Visualization
+
+Install dependencies and run the visualization script:
+
+```bash
+pip install networkx matplotlib
+python visualize_x0.py
+```
+
+Running the script generates `x0_graph.png` with a simple graph.

--- a/visualize_x0.py
+++ b/visualize_x0.py
@@ -1,0 +1,37 @@
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import networkx as nx
+
+
+def build_graph():
+    graph = nx.DiGraph()
+    edges = [
+        ("Idea", "Hypothesis"),
+        ("Hypothesis", "Experiment"),
+        ("Experiment", "Conclusion"),
+        ("Conclusion", "Idea"),
+    ]
+    graph.add_edges_from(edges)
+    return graph
+
+
+def main():
+    G = build_graph()
+    pos = nx.spring_layout(G)
+    plt.figure(figsize=(8, 6))
+    nx.draw(
+        G,
+        pos,
+        with_labels=True,
+        node_color="lightblue",
+        edgecolors="black",
+        node_size=2000,
+        arrows=True,
+    )
+    plt.title("X0 Graph Visualization")
+    plt.savefig("x0_graph.png")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `visualize_x0.py` to render a simple X0 graph using `networkx` and `matplotlib`
- document dependency installation and script usage in `README.md`

## Testing
- `pip install networkx matplotlib`
- `python visualize_x0.py && echo "visualization complete"`


------
https://chatgpt.com/codex/tasks/task_e_689a6ab9f0fc8330a85e74a96f12f8c3